### PR TITLE
[add]create log function that collect logs and send to server #15

### DIFF
--- a/src/features/types.ts
+++ b/src/features/types.ts
@@ -172,3 +172,11 @@ export interface EXHIBIT_STATE {
     exhibits: READ_EXHIBIT[];
     selectExhibit: READ_EXHIBIT;
 }
+
+export interface USER_STATISTICS_PARAMS {
+    userId: number;
+}
+export interface USER_STATISTICS_RESPONSE {
+    isErrors: boolean;
+    message: string;
+}

--- a/src/features/user/spot/SpotDetail.tsx
+++ b/src/features/user/spot/SpotDetail.tsx
@@ -38,6 +38,9 @@ import {
     selectExhibit,
     selectExhibits,
 } from '../exhibit/exhibitSlice';
+import {
+    fetchAsyncCreateUserStatistics
+} from './spotSlice';
 import GoogleMapComponent from './GoogleMapComponent';
 import ReviewList from './ReviewList';
 import { majorCategoryChipObj } from '../../../app/constant';
@@ -121,8 +124,13 @@ const SpotDetail: React.FC = () => {
     ]
 
     useEffect( () => {
+        console.log("useEffect is called")
         const fetchExhibitsLoader = async () => {
             await dispatch(fetchAsyncGetExhibits(selectedSpot.id))
+            // send logs to server only in the case of login
+            if (localStorage.startlensJWT) {
+                await dispatch(fetchAsyncCreateUserStatistics({userId: selectedSpot.id}))
+            }
         };
         fetchExhibitsLoader();
     }, [selectedSpot])

--- a/src/features/user/spot/spotSlice.ts
+++ b/src/features/user/spot/spotSlice.ts
@@ -11,7 +11,9 @@ import {
     SPOT,
     SPOT_GET_PARAMS,
     SPOT_PAGINATE_INDEX,
-    SPOT_STATE
+    SPOT_STATE,
+    USER_STATISTICS_PARAMS,
+    USER_STATISTICS_RESPONSE
 } from "../../types";
 
 
@@ -124,6 +126,23 @@ export const fetchAsyncDeleteFavorite = createAsyncThunk(
             },
         );
         return favorite;
+    }
+);
+
+export const fetchAsyncCreateUserStatistics = createAsyncThunk(
+    "userStatistics/createLogs",
+    async (userStatistics: USER_STATISTICS_PARAMS) => {
+        const res = await axios.post<USER_STATISTICS_RESPONSE>(
+            `${process.env.REACT_APP_API_URL}/api/v1/tourist/user_statistics`,
+            { "user_statistic": userStatistics },
+            {
+                headers: {
+                    "Content-Type": "application/json",
+                    Authorization: `${localStorage.startlensJWT}`,
+                },
+            }
+        );
+        return res.data
     }
 );
 


### PR DESCRIPTION
## 概要

ユーザーが観光地を訪問した際のログを収集する関数を作成。
サーバー側で１日の再訪問の重複ログ登録は記録しないようにする。
詳細は #15　を参照。