### PR TITLE
[fix]update favorite function bug

### DIFF
--- a/src/features/user/spot/spotSlice.ts
+++ b/src/features/user/spot/spotSlice.ts
@@ -472,9 +472,12 @@ export const spotSlice = createSlice({
         builder.addCase(
             fetchAsyncCreateFavorite.fulfilled,
             (state, action: PayloadAction<FAVORITE>) => {
+                // remove duplicated spot between search spots and new spots
+                const spot: SPOT[] = state.spots.filter( (spot) => spot.id === action.payload.userId)
+                const uniqueSpot: SPOT[] = spot.length === 0 ? state.newSpots.filter( (newSpot) => newSpot.id === action.payload.userId) : spot
                 return {
                     ...state,
-                    favorites: [...state.spots.filter( (spot) => spot.id === action.payload.userId), ...state.favorites]
+                    favorites: [...uniqueSpot, ...state.favorites]
                 };
             }
         );


### PR DESCRIPTION
## 概要

- 新着情報のお気に入りボタン押下時にredux stateのfavoritesが更新されずにお気に入りリストに反映されないバグが発生した。
- 新着情報と検索結果のstateの管理を分けたことからお気に入りボタン押下時の非同期関数の処理成功後の処理で問題が生じた。
